### PR TITLE
Update BCrypt.cs

### DIFF
--- a/src/BCrypt.Net/BCrypt.cs
+++ b/src/BCrypt.Net/BCrypt.cs
@@ -634,12 +634,12 @@ namespace BCrypt.Net
             {
                 return false;
             }
-            bool areSame = true;
+            int diff = 0;
             for (var i = 0; i < a.Length; i++)
             {
-                areSame &= (a[i] == b[i]);
+                diff |= (a[i] ^ b[i]);
             }
-            return areSame;
+            return diff == 0;
         }
 
 


### PR DESCRIPTION
If I understand .NET's compiled byte-code correctly, `==` can be optimized by branch prediction and possibly leak data. Using integer operations then one final comparison to 0 should be safer.