### PR TITLE
Remove unused packages for netstandard2.0

### DIFF
--- a/src/BCrypt.Net.MainPackage/BCrypt.Net.Package.csproj
+++ b/src/BCrypt.Net.MainPackage/BCrypt.Net.Package.csproj
@@ -51,15 +51,6 @@
     <Reference Include="System" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-    <PackageReference Include="System.Diagnostics.Debug" Version="4.3.0" />
-    <PackageReference Include="System.Net.Primitives" Version="4.3.0" />
-    <PackageReference Include="System.Runtime.Extensions" Version="4.3.1" />
-    <PackageReference Include="System.Security.Cryptography.Algorithms" Version="4.3.1" />
-    <PackageReference Include="System.Text.Encoding.Extensions" Version="4.3.0" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.0" />
-  </ItemGroup>
-
   <ItemGroup>
     <Compile Remove="..\BCrypt.Net\Properties\AssemblyInfo.cs" />
   </ItemGroup>

--- a/src/BCrypt.Net.StrongName/BCrypt.Net.StrongName.csproj
+++ b/src/BCrypt.Net.StrongName/BCrypt.Net.StrongName.csproj
@@ -50,16 +50,7 @@
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.0" />
     <Reference Include="System" />
   </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-    <PackageReference Include="System.Diagnostics.Debug" Version="4.3.0" />
-    <PackageReference Include="System.Net.Primitives" Version="4.3.0" />
-    <PackageReference Include="System.Runtime.Extensions" Version="4.3.1" />
-    <PackageReference Include="System.Security.Cryptography.Algorithms" Version="4.3.1" />
-    <PackageReference Include="System.Text.Encoding.Extensions" Version="4.3.0" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.0" />
-  </ItemGroup>
-
+  
   <ItemGroup>
     <Compile Remove="..\BCrypt.Net\Properties\AssemblyInfo.cs" />
   </ItemGroup>

--- a/src/BCrypt.Net/BCrypt.Net.csproj
+++ b/src/BCrypt.Net/BCrypt.Net.csproj
@@ -43,16 +43,6 @@
     <Reference Include="System" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-    <PackageReference Include="System.Diagnostics.Debug" Version="4.3.0" />
-    <PackageReference Include="System.Net.Primitives" Version="4.3.0" />
-    <PackageReference Include="System.Runtime.Extensions" Version="4.3.1" />
-    <PackageReference Include="System.Security.Cryptography.Algorithms" Version="4.3.1" />
-    <PackageReference Include="System.Text.Encoding.Extensions" Version="4.3.0" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.0" />
-  </ItemGroup>
-
-
   <PropertyGroup Condition="'$(Configuration)'=='Release'">
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\BCrypt.Net-Next.xml</DocumentationFile>
   </PropertyGroup>


### PR DESCRIPTION
Verified dotnet build and dotnet test for frameworks netstandard2.0/netcoreapp2.2. (currently on a mac) but those should be the only ones affected.