### PR TITLE
Replace Regular Expressions with custom hash parser

### DIFF
--- a/src/BCrypt.Net.UnitTests/BCryptTests.cs
+++ b/src/BCrypt.Net.UnitTests/BCryptTests.cs
@@ -596,6 +596,7 @@ namespace BCrypt.Net.UnitTests
         }
 
         [Theory]
+        [InlineData("$2$06$DCq7YPn5Rq63x1Lad4cll.TV4S6ytwfsfvkgY8jIucDrjc8deX1s.", "$2$06", "2", "06", "DCq7YPn5Rq63x1Lad4cll.TV4S6ytwfsfvkgY8jIucDrjc8deX1s.")]
         [InlineData("$2a$06$DCq7YPn5Rq63x1Lad4cll.TV4S6ytwfsfvkgY8jIucDrjc8deX1s.", "$2a$06", "2a", "06", "DCq7YPn5Rq63x1Lad4cll.TV4S6ytwfsfvkgY8jIucDrjc8deX1s.")]
         [InlineData("$2a$08$HqWuK6/Ng6sg9gQzbLrgb.Tl.ZHfXLhvt/SgVyWhQqgqcZ7ZuUtye", "$2a$08", "2a", "08", "HqWuK6/Ng6sg9gQzbLrgb.Tl.ZHfXLhvt/SgVyWhQqgqcZ7ZuUtye")]
         public void InterrogateHash_WhenHashIsValid_ParsesHash(string hash, string settings, string version, string workFactor, string rawHash)
@@ -627,6 +628,7 @@ namespace BCrypt.Net.UnitTests
         }
 
         [Theory]
+        [InlineData("$2$06$DCq7YPn5Rq63x1Lad4cll.TV4S6ytwfsfvkgY8jIucDrjc8deX1s.", 8, true)]
         [InlineData("$2a$08$HqWuK6/Ng6sg9gQzbLrgb.Tl.ZHfXLhvt/SgVyWhQqgqcZ7ZuUtye", 10, true)]
         [InlineData("$2a$08$HqWuK6/Ng6sg9gQzbLrgb.Tl.ZHfXLhvt/SgVyWhQqgqcZ7ZuUtye", 6, false)]
         public void PasswordNeedsRehash_ComparesWorkFactorInHashWithGiven(string hash, int newWorkFactor, bool expected)

--- a/src/BCrypt.Net.UnitTests/BCryptTests.cs
+++ b/src/BCrypt.Net.UnitTests/BCryptTests.cs
@@ -625,5 +625,15 @@ namespace BCrypt.Net.UnitTests
 
             Assert.Equal("Invalid Hash Format", saltParseException.Message);
         }
+
+        [Theory]
+        [InlineData("$2a$08$HqWuK6/Ng6sg9gQzbLrgb.Tl.ZHfXLhvt/SgVyWhQqgqcZ7ZuUtye", 10, true)]
+        [InlineData("$2a$08$HqWuK6/Ng6sg9gQzbLrgb.Tl.ZHfXLhvt/SgVyWhQqgqcZ7ZuUtye", 6, false)]
+        public void PasswordNeedsRehash_ComparesWorkFactorInHashWithGiven(string hash, int newWorkFactor, bool expected)
+        {
+            bool needsRehash = BCrypt.PasswordNeedsRehash(hash, newWorkFactor);
+
+            Assert.Equal(expected, needsRehash);
+        }
     }
 }

--- a/src/BCrypt.Net.UnitTests/BCryptTests.cs
+++ b/src/BCrypt.Net.UnitTests/BCryptTests.cs
@@ -246,16 +246,16 @@ namespace BCrypt.Net.UnitTests
         [InlineData("ππππππππ")]
         public void TestValidateAndReplaceEnhanced(string pass)
         {
-                string newPassword = "my new password";
-                string hashed = BCrypt.EnhancedHashPassword(pass, HashType.SHA256);
+            string newPassword = "my new password";
+            string hashed = BCrypt.EnhancedHashPassword(pass, HashType.SHA256);
 
-                var newHash = BCrypt.ValidateAndReplacePassword(pass, hashed, true, HashType.SHA256, newPassword, true, HashType.SHA512);
+            var newHash = BCrypt.ValidateAndReplacePassword(pass, hashed, true, HashType.SHA256, newPassword, true, HashType.SHA512);
 
-                var newPassValid = BCrypt.EnhancedVerify(newPassword, newHash, HashType.SHA512);
+            var newPassValid = BCrypt.EnhancedVerify(newPassword, newHash, HashType.SHA512);
 
-                Assert.True(newPassValid);
+            Assert.True(newPassValid);
 
-                Trace.Write(".");
+            Trace.Write(".");
         }
 
         [Fact()]
@@ -590,7 +590,7 @@ namespace BCrypt.Net.UnitTests
 
             var enhancedHashPassword = BCrypt.EnhancedHashPassword(myPassword, hashType: HashType.SHA384);
 
-            var validatePassword = BCrypt.EnhancedVerify(myPassword, enhancedHashPassword, hashType:HashType.SHA384);
+            var validatePassword = BCrypt.EnhancedVerify(myPassword, enhancedHashPassword, hashType: HashType.SHA384);
 
             Assert.True(validatePassword);
         }

--- a/src/BCrypt.Net/BCrypt.Net.csproj
+++ b/src/BCrypt.Net/BCrypt.Net.csproj
@@ -27,15 +27,11 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetFramework)' == 'net20' ">
-    <DefineConstants>$(DefineConstants);LEGACY</DefineConstants>
     <FrameworkPathOverride Condition="'$(TargetFramework)' == 'net20'">C:\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETFramework\v3.5\Profile\Client</FrameworkPathOverride>
   </PropertyGroup>
+  
   <PropertyGroup Condition="'$(TargetFramework)' == 'net35' ">
-    <DefineConstants>$(DefineConstants);LEGACY</DefineConstants>
     <FrameworkPathOverride Condition="'$(TargetFramework)' == 'net35'">C:\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETFramework\v3.5\Profile\Client</FrameworkPathOverride>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(TargetFramework)' == 'net40' ">
-    <DefineConstants>$(DefineConstants);LEGACY</DefineConstants>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard2.1' ">

--- a/src/BCrypt.Net/BCrypt.Net.csproj
+++ b/src/BCrypt.Net/BCrypt.Net.csproj
@@ -47,7 +47,6 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net452|net462|net472'">
-    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
     <Reference Include="System" />
   </ItemGroup>
 

--- a/src/BCrypt.Net/BCrypt.Net.csproj
+++ b/src/BCrypt.Net/BCrypt.Net.csproj
@@ -29,7 +29,7 @@
   <PropertyGroup Condition="'$(TargetFramework)' == 'net20' ">
     <FrameworkPathOverride Condition="'$(TargetFramework)' == 'net20'">C:\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETFramework\v3.5\Profile\Client</FrameworkPathOverride>
   </PropertyGroup>
-  
+
   <PropertyGroup Condition="'$(TargetFramework)' == 'net35' ">
     <FrameworkPathOverride Condition="'$(TargetFramework)' == 'net35'">C:\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETFramework\v3.5\Profile\Client</FrameworkPathOverride>
   </PropertyGroup>

--- a/src/BCrypt.Net/BCrypt.cs
+++ b/src/BCrypt.Net/BCrypt.cs
@@ -738,11 +738,7 @@ namespace BCrypt.Net
         /// <exception cref="HashInformationException"></exception>
         public static bool PasswordNeedsRehash(string hash, int newMinimumWorkLoad)
         {
-            var hashInfo = InterrogateHash(hash);
-            if (!Int32.TryParse(hashInfo.WorkFactor, out var currentWorkLoad))
-            {
-                throw new ArgumentException("Work Factor (logrounds) could not be parsed", nameof(hash));
-            }
+            int currentWorkLoad = HashParser.GetWorkFactor(hash);
 
             return currentWorkLoad < newMinimumWorkLoad;
         }

--- a/src/BCrypt.Net/BCrypt.cs
+++ b/src/BCrypt.Net/BCrypt.cs
@@ -21,7 +21,6 @@ using System;
 using System.Runtime.CompilerServices;
 using System.Security.Cryptography;
 using System.Text;
-using System.Text.RegularExpressions;
 
 namespace BCrypt.Net
 {
@@ -748,16 +747,6 @@ namespace BCrypt.Net
             return currentWorkLoad < newMinimumWorkLoad;
         }
 
-
-#if LEGACY
-        private static readonly Regex HashInformation = new Regex(@"^(?<settings>\$2[a-z]{1}?\$\d\d?)\$(?<hash>[A-Za-z0-9\./]{53})$", RegexOptions.Singleline);
-        private static readonly Regex SettingsInformation = new Regex(@"^\$(?<version>2[a-z]{1}?)\$(?<rounds>\d\d?)$", RegexOptions.Singleline);
-#else
-        private static readonly TimeSpan RegexTimeout = TimeSpan.FromMilliseconds(30);
-        private static readonly Regex HashInformation = new Regex(@"^(?<settings>\$2[a-z]{1}?\$\d\d?)\$(?<hash>[A-Za-z0-9\./]{53})$", RegexOptions.Singleline, RegexTimeout);
-        private static readonly Regex SettingsInformation = new Regex(@"^\$(?<version>2[a-z]{1}?)\$(?<rounds>\d\d?)$", RegexOptions.Singleline, RegexTimeout);
-#endif
-
         /// <summary>
         /// Takes a valid hash and outputs its component parts
         /// </summary>
@@ -767,24 +756,7 @@ namespace BCrypt.Net
         {
             try
             {
-                var hashInfo = HashInformation.Match(hash);
-
-                if (!hashInfo.Success)
-                {
-                    throw new SaltParseException("Invalid Hash Format");
-                }
-
-                var saltInfo = SettingsInformation.Match(hashInfo.Groups["settings"].Value);
-                if (!saltInfo.Success)
-                {
-                    throw new SaltParseException("Invalid Settings Format");
-                }
-
-                return new HashInformation(hashInfo.Groups["settings"].Value,
-                                            saltInfo.Groups["version"].Value,
-                                            saltInfo.Groups["rounds"].Value,
-                                            hashInfo.Groups["hash"].Value);
-
+                return HashParser.GetHashInformation(hash);
             }
             catch (Exception ex)
             {

--- a/src/BCrypt.Net/HashParser.cs
+++ b/src/BCrypt.Net/HashParser.cs
@@ -14,6 +14,16 @@ namespace BCrypt.Net
             return new HashInformation(hash.Substring(0, 6), hash.Substring(1, 2), hash.Substring(4, 2), hash.Substring(7));
         }
 
+        public static int GetWorkFactor(string hash)
+        {
+            if (!IsValidHash(hash))
+            {
+                ThrowInvalidHashFormat();
+            }
+
+            return 10 * (hash[4] - '0') + (hash[5] - '0');
+        }
+
         private static bool IsValidHash(string hash)
         {
             if (hash is null)

--- a/src/BCrypt.Net/HashParser.cs
+++ b/src/BCrypt.Net/HashParser.cs
@@ -1,0 +1,64 @@
+﻿using System;
+
+namespace BCrypt.Net
+{
+    internal static class HashParser
+    {
+        public static HashInformation GetHashInformation(string hash)
+        {
+            if (hash == null)
+            {
+                throw new ArgumentNullException(nameof(hash));
+            }
+
+            if (hash.Length != 60
+                || !hash.StartsWith("$2")
+                || !IsValidBCryptVersionChar(hash[2])
+                || hash[3] != '$'
+                || hash[6] != '$')
+            {
+                ThrowInvalidHashFormat();
+            }
+
+            string workFactorAttempt = hash.Substring(4, 2);
+            if (!int.TryParse(workFactorAttempt, out int workFactor)
+                || workFactor < 0)
+            {
+                ThrowInvalidHashFormat();
+            }
+
+            for (int i = 7; i < hash.Length; ++i)
+            {
+                if (!IsValidBCryptBase64Char(hash[i]))
+                {
+                    ThrowInvalidHashFormat();
+                }
+            }
+
+            return new HashInformation(hash.Substring(0, 6), hash.Substring(1, 2), workFactorAttempt, hash.Substring(7));
+        }
+
+        private static bool IsValidBCryptVersionChar(char value)
+        {
+            return value == 'a'
+                || value == 'b'
+                || value == 'x'
+                || value == 'y';
+        }
+
+        private static bool IsValidBCryptBase64Char(char value)
+        {
+            // Ordered by ascending ASCII value
+            return value == '.'
+                || value == '/'
+                || (value >= '0' && value <= '9')
+                || (value >= 'A' && value <= 'Z')
+                || (value >= 'a' && value <= 'z');
+        }
+
+        private static void ThrowInvalidHashFormat()
+        {
+            throw new SaltParseException("Invalid Hash Format");
+        }
+    }
+}

--- a/src/BCrypt.Net/HashParser.cs
+++ b/src/BCrypt.Net/HashParser.cs
@@ -6,36 +6,48 @@ namespace BCrypt.Net
     {
         public static HashInformation GetHashInformation(string hash)
         {
-            if (hash == null)
+            if (!IsValidHash(hash))
+            {
+                ThrowInvalidHashFormat();
+            }
+
+            return new HashInformation(hash.Substring(0, 6), hash.Substring(1, 2), hash.Substring(4, 2), hash.Substring(7));
+        }
+
+        private static bool IsValidHash(string hash)
+        {
+            if (hash is null)
             {
                 throw new ArgumentNullException(nameof(hash));
             }
 
+            // Validate settings
             if (hash.Length != 60
                 || !hash.StartsWith("$2")
                 || !IsValidBCryptVersionChar(hash[2])
                 || hash[3] != '$'
                 || hash[6] != '$')
             {
-                ThrowInvalidHashFormat();
+                return false;
             }
 
-            string workFactorAttempt = hash.Substring(4, 2);
-            if (!int.TryParse(workFactorAttempt, out int workFactor)
-                || workFactor < 0)
+            // Validate workfactor
+            if (!IsAsciiNumeric(hash[4])
+                || !IsAsciiNumeric(hash[5]))
             {
-                ThrowInvalidHashFormat();
+                return false;
             }
 
+            // Validate hash
             for (int i = 7; i < hash.Length; ++i)
             {
                 if (!IsValidBCryptBase64Char(hash[i]))
                 {
-                    ThrowInvalidHashFormat();
+                    return false;
                 }
             }
 
-            return new HashInformation(hash.Substring(0, 6), hash.Substring(1, 2), workFactorAttempt, hash.Substring(7));
+            return true;
         }
 
         private static bool IsValidBCryptVersionChar(char value)
@@ -54,6 +66,11 @@ namespace BCrypt.Net
                 || (value >= '0' && value <= '9')
                 || (value >= 'A' && value <= 'Z')
                 || (value >= 'a' && value <= 'z');
+        }
+
+        private static bool IsAsciiNumeric(char value)
+        {
+            return value >= '0' && value <= '9';
         }
 
         private static void ThrowInvalidHashFormat()

--- a/src/BCrypt.Net/HashParser.cs
+++ b/src/BCrypt.Net/HashParser.cs
@@ -4,55 +4,94 @@ namespace BCrypt.Net
 {
     internal static class HashParser
     {
+        private static readonly HashFormatDescriptor OldFormatDescriptor = new HashFormatDescriptor(versionLength: 1);
+        private static readonly HashFormatDescriptor NewFormatDescriptor = new HashFormatDescriptor(versionLength: 2);
+
         public static HashInformation GetHashInformation(string hash)
         {
-            if (!IsValidHash(hash))
+            if (!IsValidHash(hash, out var format))
             {
                 ThrowInvalidHashFormat();
             }
 
-            return new HashInformation(hash.Substring(0, 6), hash.Substring(1, 2), hash.Substring(4, 2), hash.Substring(7));
+            return new HashInformation(
+                hash.Substring(0, format.SettingLength),
+                hash.Substring(1, format.VersionLength),
+                hash.Substring(format.WorkfactorOffset, 2),
+                hash.Substring(format.HashOffset));
         }
 
         public static int GetWorkFactor(string hash)
         {
-            if (!IsValidHash(hash))
+            if (!IsValidHash(hash, out var format))
             {
                 ThrowInvalidHashFormat();
             }
 
-            return 10 * (hash[4] - '0') + (hash[5] - '0');
+            int offset = format.WorkfactorOffset;
+
+            return 10 * (hash[offset] - '0') + (hash[offset + 1] - '0');
         }
 
-        private static bool IsValidHash(string hash)
+        private static bool IsValidHash(string hash, out HashFormatDescriptor format)
         {
             if (hash is null)
             {
                 throw new ArgumentNullException(nameof(hash));
             }
 
-            // Validate settings
-            if (hash.Length != 60
-                || !hash.StartsWith("$2")
-                || !IsValidBCryptVersionChar(hash[2])
-                || hash[3] != '$'
-                || hash[6] != '$')
+            if (hash.Length != 59 && hash.Length != 60)
             {
+                // Incorrect full hash length
+                format = null;
+                return false;
+            }
+
+            if (!hash.StartsWith("$2"))
+            {
+                // Not a bcrypt hash
+                format = null;
+                return false;
+            }
+
+            // Validate version
+            int offset = 2;
+            if (IsValidBCryptVersionChar(hash[offset]))
+            {
+                offset++;
+                format = NewFormatDescriptor;
+            }
+            else
+            {
+                format = OldFormatDescriptor;
+            }
+
+            if (hash[offset++] != '$')
+            {
+                format = null;
                 return false;
             }
 
             // Validate workfactor
-            if (!IsAsciiNumeric(hash[4])
-                || !IsAsciiNumeric(hash[5]))
+            if (!IsAsciiNumeric(hash[offset++])
+                || !IsAsciiNumeric(hash[offset++]))
             {
+                format = null;
+                return false;
+            }
+
+            if (hash[offset++] != '$')
+            {
+                format = null;
                 return false;
             }
 
             // Validate hash
-            for (int i = 7; i < hash.Length; ++i)
+            for (int i = offset; i < hash.Length; ++i)
             {
                 if (!IsValidBCryptBase64Char(hash[i]))
                 {
+                    format = null;
                     return false;
                 }
             }
@@ -86,6 +125,24 @@ namespace BCrypt.Net
         private static void ThrowInvalidHashFormat()
         {
             throw new SaltParseException("Invalid Hash Format");
+        }
+
+        private class HashFormatDescriptor
+        {
+            public HashFormatDescriptor(int versionLength)
+            {
+                VersionLength = versionLength;
+                WorkfactorOffset = 1 + VersionLength + 1;
+                SettingLength = WorkfactorOffset + 2;
+                HashOffset = SettingLength + 1;
+            }
+            public int VersionLength { get; }
+
+            public int WorkfactorOffset { get; }
+
+            public int SettingLength { get; }
+
+            public int HashOffset { get; }
         }
     }
 }


### PR DESCRIPTION
Removed the dependency on regular expressions and added a quite simple hash parser.

Improves performance for `PasswordNeedsRehash` roughly 8x, while reducing memory usage by 6x.

Before:

|              Method |                 text |                 hash |                value |             Mean |         Error |        StdDev |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|-------------------- |--------------------- |--------------------- |--------------------- |-----------------:|--------------:|--------------:|-------:|------:|------:|----------:|
| PasswordNeedsRehash |                    ? |                    ? |                    ? |       1,626.2 ns |      14.83 ns |      13.15 ns | 0.3166 |     - |     - |    1328 B |

After:

|              Method |                 text |                 hash |                value |             Mean |           Error |          StdDev |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|-------------------- |--------------------- |--------------------- |--------------------- |-----------------:|----------------:|----------------:|-------:|------:|------:|----------:|
| PasswordNeedsRehash |                    ? |                    ? |                    ? |         228.8 ns |         1.06 ns |         0.94 ns | 0.0668 |     - |     - |     280 B |