### PR TITLE
Update readme to reflect default hash factor

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -36,7 +36,7 @@ To Verify a password against a hash (assuming you've stored the hash and retriev
 BCrypt.Verify("my password", passwordHash);
 ```
 
-This implementation on hashing will generate a salt automatically for you with the work factor (2^number of rounds) set to 10 (which matches the default across most implementation and is currently viewed as a good level of security/risk).
+This implementation on hashing will generate a salt automatically for you with the work factor (2^number of rounds) set to 11 (which matches the default across most implementation and is currently viewed as a good level of security/risk).
 
 To save you the maths a small table covering the iterations is provided below. The minimum allowed in this library is 4 for compatibility, the maximum is 31 (at 31 your processor will be wishing for death).
 


### PR DESCRIPTION
In the current readme it says the default work factor is 10, while it really is 11.