### PR TITLE
Use License Expression for NuGet Package and add URLs

### DIFF
--- a/src/BCrypt.Net.MainPackage/BCrypt.Net.Package.csproj
+++ b/src/BCrypt.Net.MainPackage/BCrypt.Net.Package.csproj
@@ -15,8 +15,9 @@
     <Copyright>2006-2021 Chris McKee, Ryan D. Emerl, Damien Miller</Copyright>
     <Summary>BCrypt.Net, C# implementation of BCrypt, OpenBSD-style Blowfish password hashing</Summary>
     <Description>A fixed, enhanced and namespace compatible version of BCrypt.Net port of jBCrypt implemented in C#. It uses a variant of the Blowfish encryption algorithm’s keying schedule, and introduces a work factor, which allows you to determine how expensive the hash function will be, allowing the algorithm to be "future-proof".</Description>
-    <!--<PackageLicenseExpression>MIT</PackageLicenseExpression>-->
-    <PackageLicenseUrl>https://github.com/BcryptNet/bcrypt.net/blob/main/licence.txt</PackageLicenseUrl>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PackageProjectUrl>https://github.com/BcryptNet/bcrypt.net</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/BcryptNet/bcrypt.net</RepositoryUrl>
 
     <SignAssembly>true</SignAssembly>
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>

--- a/src/BCrypt.Net.StrongName/BCrypt.Net.StrongName.csproj
+++ b/src/BCrypt.Net.StrongName/BCrypt.Net.StrongName.csproj
@@ -15,8 +15,9 @@
     <Copyright>2006-2021 Chris McKee, Ryan D. Emerl, Damien Miller</Copyright>
     <Summary>BCrypt.Net, C# implementation of BCrypt, OpenBSD-style Blowfish password hashing</Summary>
     <Description>A fixed, enhanced and namespace compatible version of BCrypt.Net port of jBCrypt implemented in C#. It uses a variant of the Blowfish encryption algorithm’s keying schedule, and introduces a work factor, which allows you to determine how expensive the hash function will be, allowing the algorithm to be "future-proof".</Description>
-    <!--<PackageLicenseExpression>MIT</PackageLicenseExpression>-->
-    <PackageLicenseUrl>https://github.com/BcryptNet/bcrypt.net/blob/main/licence.txt</PackageLicenseUrl>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PackageProjectUrl>https://github.com/BcryptNet/bcrypt.net</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/BcryptNet/bcrypt.net</RepositoryUrl>
     
     <SignAssembly>true</SignAssembly>
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>

--- a/src/BCrypt.Net/BCrypt.Net.csproj
+++ b/src/BCrypt.Net/BCrypt.Net.csproj
@@ -15,8 +15,9 @@
     <Copyright>2006-2021 Chris McKee, Ryan D. Emerl, Damien Miller</Copyright>
     <Summary>BCrypt.Net, C# implementation of BCrypt, OpenBSD-style Blowfish password hashing</Summary>
     <Description>A fixed, enhanced and namespace compatible version of BCrypt.Net port of jBCrypt implemented in C#. It uses a variant of the Blowfish encryption algorithm’s keying schedule, and introduces a work factor, which allows you to determine how expensive the hash function will be, allowing the algorithm to be "future-proof".</Description>
-    <!--<PackageLicenseExpression>MIT</PackageLicenseExpression>-->
-    <PackageLicenseUrl>https://github.com/BcryptNet/bcrypt.net/blob/main/licence.txt</PackageLicenseUrl>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PackageProjectUrl>https://github.com/BcryptNet/bcrypt.net</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/BcryptNet/bcrypt.net</RepositoryUrl>
 
     <Version>4.0.3</Version>
     <Configurations>Debug;Release</Configurations>


### PR DESCRIPTION
LicenseUrl is deprecated, see https://github.com/NuGet/Announcements/issues/32